### PR TITLE
Feat/38: Read notifications

### DIFF
--- a/api/src/controllers/notification.ts
+++ b/api/src/controllers/notification.ts
@@ -37,4 +37,31 @@ export default class NotificationController {
             ErrorUtils.handleError(err, res);
         }
     }
+
+    public async readNotification(req: Request, res: Response) {
+        if (!ValidationUtils.validateUserLoggedIn(req, res)) return res;
+
+        const notificationId = req.params["notificationId"];
+        if (!this.validateNotificationId(notificationId, res)) return res;
+
+        try {
+            await this.notificationService.readNotification(
+                parseInt(notificationId)
+            );
+            return res.status(204).json();
+        } catch (err: any) {
+            console.error(err.message);
+            return ErrorUtils.handleError(err, res);
+        }
+    }
+
+    private validateNotificationId(notificationId: any, res: Response) {
+        if (ValidationUtils.isEmpty(notificationId) || !ValidationUtils.isPositiveNumber(notificationId)) {
+            res.status(400).json({
+                message: "Bad request: Notification ID necessary",
+            });
+            return false;
+        }
+        return true;
+    }
 }

--- a/api/src/controllers/notification.ts
+++ b/api/src/controllers/notification.ts
@@ -56,7 +56,10 @@ export default class NotificationController {
     }
 
     private validateNotificationId(notificationId: any, res: Response) {
-        if (ValidationUtils.isEmpty(notificationId) || !ValidationUtils.isPositiveNumber(notificationId)) {
+        if (
+            ValidationUtils.isEmpty(notificationId) ||
+            !ValidationUtils.isPositiveNumber(notificationId)
+        ) {
             res.status(400).json({
                 message: "Bad request: Notification ID necessary",
             });

--- a/api/src/errors/NotificationAlreadyReadError.ts
+++ b/api/src/errors/NotificationAlreadyReadError.ts
@@ -5,4 +5,3 @@ export class NotificationAlreadyReadError extends MyTVListError {
         super("Notification has already been read", 405);
     }
 }
-

--- a/api/src/errors/NotificationAlreadyReadError.ts
+++ b/api/src/errors/NotificationAlreadyReadError.ts
@@ -1,0 +1,8 @@
+import { MyTVListError } from "./MyTVListError";
+
+export class NotificationAlreadyReadError extends MyTVListError {
+    public constructor() {
+        super("Notification has already been read", 405);
+    }
+}
+

--- a/api/src/errors/NotificationNotFoundError.ts
+++ b/api/src/errors/NotificationNotFoundError.ts
@@ -1,0 +1,7 @@
+import { MyTVListError } from "./MyTVListError";
+
+export class NotificationNotFoundError extends MyTVListError {
+    public constructor() {
+        super("Notification not found", 404);
+    }
+}

--- a/api/src/routes/notification.ts
+++ b/api/src/routes/notification.ts
@@ -16,3 +16,9 @@ notificationRouter.get(
     auth,
     async (req, res) => await controller.listNotifications(req, res)
 );
+
+notificationRouter.delete(
+    "/:notificationId",
+    auth,
+    async (req, res) => await controller.readNotification(req, res)
+);

--- a/api/src/services/notificationService.ts
+++ b/api/src/services/notificationService.ts
@@ -1,5 +1,8 @@
 import { Repository } from "typeorm";
 import { NotificationEntity } from "../entity/notification.entity";
+import { NotificationNotFoundError } from "../errors/NotificationNotFoundError";
+import { ValidationUtils } from "../utils/validationUtils";
+import { NotificationAlreadyReadError } from "../errors/NotificationAlreadyReadError";
 
 export default class NotificationService {
     private notificationRepository: Repository<NotificationEntity>;
@@ -19,5 +22,25 @@ export default class NotificationService {
         });
 
         return notifications;
+    }
+
+    public async readNotification(notificationId: number) {
+        const notification = await this.notificationRepository.findOne({
+            where: {
+                Id: notificationId,
+            },
+        });
+
+        if (!notification) {
+            throw new NotificationNotFoundError();
+        }
+
+        if (!ValidationUtils.isNull(notification.ReadAt)) {
+            throw new NotificationAlreadyReadError();
+        }
+
+        await this.notificationRepository.update(notificationId, {
+            ReadAt: new Date(),
+        });
     }
 }

--- a/api/src/services/notificationService.ts
+++ b/api/src/services/notificationService.ts
@@ -29,6 +29,7 @@ export default class NotificationService {
             where: {
                 Id: notificationId,
             },
+            withDeleted: true,
         });
 
         if (!notification) {

--- a/api/src/utils/validationUtils.ts
+++ b/api/src/utils/validationUtils.ts
@@ -15,7 +15,7 @@ export class ValidationUtils {
     }
 
     static isPositiveNumber(str) {
-        const numberRegex = /^[1-9]+$/;
+        const numberRegex = /^[0-9]*[1-9][0-9]*$/;
         return numberRegex.test(str);
     }
 

--- a/api/tests/controllers/notification.test.ts
+++ b/api/tests/controllers/notification.test.ts
@@ -1,4 +1,6 @@
 import NotificationController from "../../src/controllers/notification";
+import { NotificationAlreadyReadError } from "../../src/errors/NotificationAlreadyReadError";
+import { NotificationNotFoundError } from "../../src/errors/NotificationNotFoundError";
 
 describe("Notification controller", () => {
     let notificationController: NotificationController;
@@ -7,6 +9,7 @@ describe("Notification controller", () => {
     beforeEach(() => {
         notificationService = {
             listNotifications: jest.fn(),
+            readNotification: jest.fn(),
         };
         notificationController = new NotificationController(
             notificationService
@@ -156,6 +159,161 @@ describe("Notification controller", () => {
                     read: true,
                 },
             ]);
+        });
+    });
+
+    describe("readNotification", () => {
+        test("Should mark notification as read", async () => {
+            const req: any = {
+                user: {
+                    id: 1,
+                },
+                params: {
+                    notificationId: 1,
+                },
+            };
+
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+
+            notificationService.readNotification.mockResolvedValueOnce({});
+
+            await notificationController.readNotification(req, res);
+
+            expect(notificationService.readNotification).toHaveBeenCalledWith(
+                1
+            );
+            expect(res.status).toHaveBeenCalledWith(204);
+            expect(res.json).toHaveBeenCalledWith();
+        });
+
+        test("Should return NotificationNotFound error", async () => {
+            const req: any = {
+                user: {
+                    id: 1,
+                },
+                params: {
+                    notificationId: 10,
+                },
+            };
+
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+
+            notificationService.readNotification.mockRejectedValueOnce(
+                new NotificationNotFoundError()
+            );
+
+            await notificationController.readNotification(req, res);
+
+            expect(notificationService.readNotification).toHaveBeenCalledWith(
+                10
+            );
+            expect(res.status).toHaveBeenCalledWith(404);
+            expect(res.json).toHaveBeenCalledWith({
+                message: "Notification not found",
+            });
+        });
+
+        test("Should return NotificationAlreadyRead error", async () => {
+            const req: any = {
+                user: {
+                    id: 1,
+                },
+                params: {
+                    notificationId: "3",
+                },
+            };
+
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+
+            notificationService.readNotification.mockRejectedValueOnce(
+                new NotificationAlreadyReadError()
+            );
+
+            await notificationController.readNotification(req, res);
+
+            expect(notificationService.readNotification).toHaveBeenCalledWith(
+                3
+            );
+            expect(res.status).toHaveBeenCalledWith(405);
+            expect(res.json).toHaveBeenCalledWith({
+                message: "Notification has already been read",
+            });
+        });
+
+        test("Should return invalid notification id error", async () => {
+            const req: any = {
+                user: {
+                    id: 1,
+                },
+                params: {
+                    notificationId: 0,
+                },
+            };
+
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+
+            notificationService.readNotification.mockResolvedValueOnce({});
+
+            await notificationController.readNotification(req, res);
+
+            expect(notificationService.readNotification).not.toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith({
+                message: "Bad request: Notification ID necessary",
+            });
+        });
+
+        test("Should return 500 when an error occurs", async () => {
+            const req: any = {
+                params: {
+                    notificationId: 1,
+                },
+                user: {
+                    id: 1,
+                },
+            };
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+            notificationService.readNotification.mockRejectedValueOnce(new Error());
+
+            await notificationController.readNotification(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(500);
+            expect(res.json).toHaveBeenCalledWith({
+                message: "Internal server error",
+            });
+        });
+
+        test("Should return 401 when user is not logged in", async () => {
+            const req: any = {
+                params: {
+                    notificationId: 1,
+                },
+                user: undefined,
+            };
+            const res: any = {
+                status: jest.fn().mockReturnThis(),
+                json: jest.fn(),
+            };
+
+            await notificationController.readNotification(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(401);
+            expect(res.json).toHaveBeenCalledWith({ message: "Unauthorized" });
         });
     });
 });

--- a/api/tests/controllers/notification.test.ts
+++ b/api/tests/controllers/notification.test.ts
@@ -288,7 +288,9 @@ describe("Notification controller", () => {
                 status: jest.fn().mockReturnThis(),
                 json: jest.fn(),
             };
-            notificationService.readNotification.mockRejectedValueOnce(new Error());
+            notificationService.readNotification.mockRejectedValueOnce(
+                new Error()
+            );
 
             await notificationController.readNotification(req, res);
 

--- a/api/tests/utils/validationUtils.test.ts
+++ b/api/tests/utils/validationUtils.test.ts
@@ -72,6 +72,11 @@ describe("isNumber", () => {
         expect(response).toEqual(true);
     });
 
+    test("Should return true if string is number 10", () => {
+        const response = ValidationUtils.isPositiveNumber("10");
+        expect(response).toEqual(true);
+    });
+
     test("Should return true if string is number 43243", () => {
         const response = ValidationUtils.isPositiveNumber("43243");
         expect(response).toEqual(true);


### PR DESCRIPTION
## Description
This PR adds the ability to read notifications. This is done by setting the `ReadAt` property of the notification to the time that it has been read.

> **Observation**
A bug was found in the `ValidationUtils.isPositiveNumber` method. It was not recognizing numbers finishing in 0 as positive. The bug was fixed and a new test case was added.

## Main issue

- #36 

## Related issues

- #38

## Pull request type

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] Other (please describe):

## Tests

-   [x] All unit tests passed
-   [x] Added new unit tests

## Documentation

-   [ ] Add documentation
-   [ ] Update documentation
