### PR TITLE
Feat/39: Create Notifications on comment reply

### DIFF
--- a/api/src/errors/EmptyNotificationError.ts
+++ b/api/src/errors/EmptyNotificationError.ts
@@ -5,4 +5,3 @@ export class EmptyNotificationError extends MyTVListError {
         super("Notification text was empty", 404);
     }
 }
-

--- a/api/src/errors/EmptyNotificationError.ts
+++ b/api/src/errors/EmptyNotificationError.ts
@@ -1,0 +1,8 @@
+import { MyTVListError } from "./MyTVListError";
+
+export class EmptyNotificationError extends MyTVListError {
+    public constructor() {
+        super("Notification text was empty", 404);
+    }
+}
+

--- a/api/src/errors/UserIdError.ts
+++ b/api/src/errors/UserIdError.ts
@@ -5,4 +5,3 @@ export class UserIdError extends MyTVListError {
         super("User id error", 404);
     }
 }
-

--- a/api/src/errors/UserIdError.ts
+++ b/api/src/errors/UserIdError.ts
@@ -1,0 +1,8 @@
+import { MyTVListError } from "./MyTVListError";
+
+export class UserIdError extends MyTVListError {
+    public constructor() {
+        super("User id error", 404);
+    }
+}
+

--- a/api/src/models/notification.ts
+++ b/api/src/models/notification.ts
@@ -9,17 +9,27 @@ export interface Notification {
 }
 
 export class NotificationParser {
-    public static parseNotification(
-        notificationEntity: NotificationEntity
-    ): Notification {
-        return {
+    public static parseNotification(notificationEntity: any): Notification {
+        if (ValidationUtils.isNull(notificationEntity)) {
+            return {} as Notification;
+        }
+
+        const notification = {
             id: notificationEntity.Id,
             userId: ValidationUtils.isNull(notificationEntity.User)
                 ? null
                 : notificationEntity.User.Id,
             text: notificationEntity.Text,
-            read: notificationEntity.ReadAt !== null,
+            read: !ValidationUtils.isNull(notificationEntity.ReadAt),
         };
+
+        Object.keys(notification).forEach(
+            (key) =>
+                ValidationUtils.isNull(notification[key]) &&
+                delete notification[key]
+        );
+
+        return notification;
     }
 
     public static parseNotifications(

--- a/api/src/routes/comment.ts
+++ b/api/src/routes/comment.ts
@@ -5,12 +5,15 @@ import { MediaEntity } from "../entity/media.entity";
 import CommentService from "../services/commentService";
 import appDataSource from "../config/ormconfig";
 import auth from "../middleware/auth";
+import { NotificationEntity } from "../entity/notification.entity";
 
 const commentRouter = express.Router();
 
 const commentRepository = appDataSource.getRepository(CommentEntity);
 const mediaRepository = appDataSource.getRepository(MediaEntity);
-const service = new CommentService(commentRepository, mediaRepository);
+const notificationRepository = appDataSource.getRepository(NotificationEntity);
+
+const service = new CommentService(commentRepository, mediaRepository, notificationRepository);
 const controller = new CommentController(service);
 
 commentRouter.get(

--- a/api/src/routes/comment.ts
+++ b/api/src/routes/comment.ts
@@ -13,7 +13,11 @@ const commentRepository = appDataSource.getRepository(CommentEntity);
 const mediaRepository = appDataSource.getRepository(MediaEntity);
 const notificationRepository = appDataSource.getRepository(NotificationEntity);
 
-const service = new CommentService(commentRepository, mediaRepository, notificationRepository);
+const service = new CommentService(
+    commentRepository,
+    mediaRepository,
+    notificationRepository
+);
 const controller = new CommentController(service);
 
 commentRouter.get(

--- a/api/src/services/commentService.ts
+++ b/api/src/services/commentService.ts
@@ -20,7 +20,7 @@ class ReplyNotification extends NotificationCreationService {
     public constructor(
         notificationRepository: Repository<NotificationEntity>,
         comment: Comment,
-        parentUserId: number,
+        parentUserId: number
     ) {
         super(notificationRepository);
 
@@ -109,7 +109,7 @@ export default class CommentService {
             const notificaton = new ReplyNotification(
                 this.notificationRepository,
                 comment,
-                parentUserId,
+                parentUserId
             );
 
             notificaton.saveNotification(parentUserId);

--- a/api/src/services/commentService.ts
+++ b/api/src/services/commentService.ts
@@ -7,35 +7,8 @@ import { CommentNotFoundError } from "../errors/CommentNotFoundError";
 import { CommentNotOwnedError } from "../errors/CommentNotOwnedError";
 import { ValidationUtils } from "../../src/utils/validationUtils";
 import { Comment, CommentParser } from "../models/comment";
-import NotificationCreationService from "./notificationCreationService";
-import {
-    NotificationEntity,
-    NotificationType,
-} from "../entity/notification.entity";
-
-class ReplyNotification extends NotificationCreationService {
-    private comment: Comment;
-    private parentUserId: number;
-
-    public constructor(
-        notificationRepository: Repository<NotificationEntity>,
-        comment: Comment,
-        parentUserId: number
-    ) {
-        super(notificationRepository);
-
-        this.comment = comment;
-        this.parentUserId = parentUserId;
-    }
-
-    getNotificationText(): string {
-        return `User ${this.parentUserId} replied to your comment made at ${this.comment.mediaId}.`;
-    }
-
-    getNotificationType(): NotificationType {
-        return NotificationType.COMMENT_REPLY;
-    }
-}
+import { NotificationEntity } from "../entity/notification.entity";
+import { ReplyNotification } from "./replyNotification";
 
 export default class CommentService {
     private commentRepository: Repository<CommentEntity>;
@@ -108,11 +81,11 @@ export default class CommentService {
 
             const notificaton = new ReplyNotification(
                 this.notificationRepository,
-                comment,
-                parentUserId
+                parentUserId,
+                comment
             );
 
-            notificaton.saveNotification(parentUserId);
+            notificaton.saveNotification();
         }
 
         return comment;

--- a/api/src/services/commentService.ts
+++ b/api/src/services/commentService.ts
@@ -6,18 +6,50 @@ import { CommentParentNotFoundError } from "../errors/CommentParentNotFoundError
 import { CommentNotFoundError } from "../errors/CommentNotFoundError";
 import { CommentNotOwnedError } from "../errors/CommentNotOwnedError";
 import { ValidationUtils } from "../../src/utils/validationUtils";
-import { CommentParser } from "../models/comment";
+import { Comment, CommentParser } from "../models/comment";
+import NotificationCreationService from "./notificationCreationService";
+import {
+    NotificationEntity,
+    NotificationType,
+} from "../entity/notification.entity";
+
+class ReplyNotification extends NotificationCreationService {
+    private comment: Comment;
+    private parentUserId: number;
+
+    public constructor(
+        notificationRepository: Repository<NotificationEntity>,
+        comment: Comment,
+        parentUserId: number,
+    ) {
+        super(notificationRepository);
+
+        this.comment = comment;
+        this.parentUserId = parentUserId;
+    }
+
+    getNotificationText(): string {
+        return `User ${this.parentUserId} replied to your comment made at ${this.comment.mediaId}.`;
+    }
+
+    getNotificationType(): NotificationType {
+        return NotificationType.COMMENT_REPLY;
+    }
+}
 
 export default class CommentService {
     private commentRepository: Repository<CommentEntity>;
     private mediaRepository: Repository<MediaEntity>;
+    private notificationRepository: Repository<NotificationEntity>;
 
     public constructor(
         commentRepository: Repository<CommentEntity>,
-        mediaRepository: Repository<MediaEntity>
+        mediaRepository: Repository<MediaEntity>,
+        notificationRepository: Repository<NotificationEntity>
     ) {
         this.commentRepository = commentRepository;
         this.mediaRepository = mediaRepository;
+        this.notificationRepository = notificationRepository;
     }
 
     public async listComments(mediaId: number) {
@@ -49,13 +81,17 @@ export default class CommentService {
             throw new MediaNotFoundError();
         }
 
+        let parentComment = {} as Comment;
+
         if (!ValidationUtils.isEmpty(parentId)) {
-            const commentExists = await this.commentRepository.exist({
+            const parentCommentEntity = await this.commentRepository.findOne({
                 where: { Id: parentId as number },
             });
-            if (!commentExists) {
+            if (!parentCommentEntity) {
                 throw new CommentParentNotFoundError();
             }
+
+            parentComment = CommentParser.parseComment(parentCommentEntity);
         }
 
         const commentEntity = await this.commentRepository.save({
@@ -65,7 +101,21 @@ export default class CommentService {
             Content: content,
         } as CommentEntity);
 
-        return CommentParser.parseComment(commentEntity);
+        const comment = CommentParser.parseComment(commentEntity);
+
+        if (parentComment) {
+            const parentUserId = parentComment.userId as number;
+
+            const notificaton = new ReplyNotification(
+                this.notificationRepository,
+                comment,
+                parentUserId,
+            );
+
+            notificaton.saveNotification(parentUserId);
+        }
+
+        return comment;
     }
 
     public async updateComment(

--- a/api/src/services/notificationCreationService.ts
+++ b/api/src/services/notificationCreationService.ts
@@ -10,16 +10,18 @@ import { EmptyNotificationError } from "../errors/EmptyNotificationError";
 
 export default abstract class NotificationCreationService {
     private notificationRepository: Repository<NotificationEntity>;
+    protected userId: number;
 
-    public constructor(notificationRepository: Repository<NotificationEntity>) {
+    public constructor(notificationRepository: Repository<NotificationEntity>, userId: number) {
         this.notificationRepository = notificationRepository;
+        this.userId = userId;
     }
 
     abstract getNotificationText(): string;
     abstract getNotificationType(): NotificationType;
 
-    public async saveNotification(userId: number) {
-        if (!ValidationUtils.isPositiveNumber(userId)) {
+    public async saveNotification() {
+        if (!ValidationUtils.isPositiveNumber(this.userId)) {
             throw new UserIdError();
         }
 
@@ -32,7 +34,7 @@ export default abstract class NotificationCreationService {
 
         const notification = await this.notificationRepository.save({
             User: {
-                Id: userId,
+                Id: this.userId,
             },
             Text: text,
             Type: type,

--- a/api/src/services/notificationCreationService.ts
+++ b/api/src/services/notificationCreationService.ts
@@ -1,5 +1,8 @@
 import { Repository } from "typeorm";
-import { NotificationEntity, NotificationType } from "../entity/notification.entity";
+import {
+    NotificationEntity,
+    NotificationType,
+} from "../entity/notification.entity";
 import { NotificationParser } from "../models/notification";
 import { ValidationUtils } from "../utils/validationUtils";
 import { UserIdError } from "../errors/UserIdError";
@@ -12,8 +15,8 @@ export default abstract class NotificationCreationService {
         this.notificationRepository = notificationRepository;
     }
 
-    abstract getNotificationText() : string;
-    abstract getNotificationType() : NotificationType;
+    abstract getNotificationText(): string;
+    abstract getNotificationType(): NotificationType;
 
     public async saveNotification(userId: number) {
         if (!ValidationUtils.isPositiveNumber(userId)) {
@@ -36,6 +39,5 @@ export default abstract class NotificationCreationService {
         } as NotificationEntity);
 
         return NotificationParser.parseNotification(notification);
-    } 
+    }
 }
-

--- a/api/src/services/notificationCreationService.ts
+++ b/api/src/services/notificationCreationService.ts
@@ -1,6 +1,9 @@
 import { Repository } from "typeorm";
 import { NotificationEntity, NotificationType } from "../entity/notification.entity";
 import { NotificationParser } from "../models/notification";
+import { ValidationUtils } from "../utils/validationUtils";
+import { UserIdError } from "../errors/UserIdError";
+import { EmptyNotificationError } from "../errors/EmptyNotificationError";
 
 export default abstract class NotificationCreationService {
     private notificationRepository: Repository<NotificationEntity>;
@@ -13,8 +16,16 @@ export default abstract class NotificationCreationService {
     abstract getNotificationType() : NotificationType;
 
     public async saveNotification(userId: number) {
+        if (!ValidationUtils.isPositiveNumber(userId)) {
+            throw new UserIdError();
+        }
+
         const text: string = this.getNotificationText();
         const type: NotificationType = this.getNotificationType();
+
+        if (ValidationUtils.isEmpty(text)) {
+            throw new EmptyNotificationError();
+        }
 
         const notification = await this.notificationRepository.save({
             User: {

--- a/api/src/services/notificationCreationService.ts
+++ b/api/src/services/notificationCreationService.ts
@@ -12,7 +12,10 @@ export default abstract class NotificationCreationService {
     private notificationRepository: Repository<NotificationEntity>;
     protected userId: number;
 
-    public constructor(notificationRepository: Repository<NotificationEntity>, userId: number) {
+    public constructor(
+        notificationRepository: Repository<NotificationEntity>,
+        userId: number
+    ) {
         this.notificationRepository = notificationRepository;
         this.userId = userId;
     }

--- a/api/src/services/notificationCreationService.ts
+++ b/api/src/services/notificationCreationService.ts
@@ -1,0 +1,30 @@
+import { Repository } from "typeorm";
+import { NotificationEntity, NotificationType } from "../entity/notification.entity";
+import { NotificationParser } from "../models/notification";
+
+export default abstract class NotificationCreationService {
+    private notificationRepository: Repository<NotificationEntity>;
+
+    public constructor(notificationRepository: Repository<NotificationEntity>) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    abstract getNotificationText() : string;
+    abstract getNotificationType() : NotificationType;
+
+    public async saveNotification(userId: number) {
+        const text: string = this.getNotificationText();
+        const type: NotificationType = this.getNotificationType();
+
+        const notification = await this.notificationRepository.save({
+            User: {
+                Id: userId,
+            },
+            Text: text,
+            Type: type,
+        } as NotificationEntity);
+
+        return NotificationParser.parseNotification(notification);
+    } 
+}
+

--- a/api/src/services/replyNotification.ts
+++ b/api/src/services/replyNotification.ts
@@ -1,0 +1,29 @@
+import {
+    NotificationEntity,
+    NotificationType,
+} from "../entity/notification.entity";
+import NotificationCreationService from "./notificationCreationService";
+import { Comment } from "../models/comment";
+import { Repository } from "typeorm";
+
+export class ReplyNotification extends NotificationCreationService {
+    private comment: Comment;
+
+    public constructor(
+        notificationRepository: Repository<NotificationEntity>,
+        userId: number,
+        comment: Comment
+    ) {
+        super(notificationRepository, userId);
+
+        this.comment = comment;
+    }
+
+    getNotificationText(): string {
+        return `User ${this.userId} replied to your comment made at ${this.comment.mediaId}.`;
+    }
+
+    getNotificationType(): NotificationType {
+        return NotificationType.COMMENT_REPLY;
+    }
+}

--- a/api/tests/controllers/notification.test.ts
+++ b/api/tests/controllers/notification.test.ts
@@ -155,7 +155,6 @@ describe("Notification controller", () => {
                 {
                     id: 2,
                     text: "text 2",
-                    userId: null,
                     read: true,
                 },
             ]);

--- a/api/tests/models/notification.test.ts
+++ b/api/tests/models/notification.test.ts
@@ -1,0 +1,24 @@
+import { NotificationParser } from "../../src/models/notification";
+
+describe("parseNotification", () => {
+    test("Should return read false from empty object", () => {
+        const obj = {};
+        const notification = NotificationParser.parseNotification(obj);
+
+        expect(notification).toEqual({ read: false });
+    });
+
+    test("Should return empty notification from undefined object", () => {
+        const obj = undefined;
+        const notification = NotificationParser.parseNotification(obj);
+
+        expect(notification).toEqual({});
+    });
+
+    test("Should return read as true from object with ReadAt attribute", () => {
+        const obj = { ReadAt: new Date() };
+        const notification = NotificationParser.parseNotification(obj);
+
+        expect(notification).toEqual({ read: true });
+    });
+});

--- a/api/tests/services/commentService.test.ts
+++ b/api/tests/services/commentService.test.ts
@@ -122,7 +122,9 @@ describe("Comment Service", () => {
 
         test("Should create comment when media exists and parent comment exists", async () => {
             mediaRepositoryMock.exist.mockReturnValueOnce(true);
-            commentRepositoryMock.findOne.mockReturnValueOnce(makeCommentEntityMock());
+            commentRepositoryMock.findOne.mockReturnValueOnce(
+                makeCommentEntityMock()
+            );
             const commentEntityMock = makeCommentEntityMock({ ParentId: 1 });
             commentRepositoryMock.save.mockReturnValueOnce(commentEntityMock);
 

--- a/api/tests/services/commentService.test.ts
+++ b/api/tests/services/commentService.test.ts
@@ -33,6 +33,7 @@ describe("Comment Service", () => {
     let commentService: CommentService;
     let commentRepositoryMock: any;
     let mediaRepositoryMock: any;
+    let notificationRepositoryMock: any;
 
     beforeEach(() => {
         commentRepositoryMock = {
@@ -47,9 +48,14 @@ describe("Comment Service", () => {
             exist: jest.fn(),
         };
 
+        notificationRepositoryMock = {
+            save: jest.fn(),
+        };
+
         commentService = new CommentService(
             commentRepositoryMock,
-            mediaRepositoryMock
+            mediaRepositoryMock,
+            notificationRepositoryMock
         );
     });
 
@@ -116,7 +122,7 @@ describe("Comment Service", () => {
 
         test("Should create comment when media exists and parent comment exists", async () => {
             mediaRepositoryMock.exist.mockReturnValueOnce(true);
-            commentRepositoryMock.exist.mockReturnValueOnce(true);
+            commentRepositoryMock.findOne.mockReturnValueOnce(makeCommentEntityMock());
             const commentEntityMock = makeCommentEntityMock({ ParentId: 1 });
             commentRepositoryMock.save.mockReturnValueOnce(commentEntityMock);
 

--- a/api/tests/services/notificationCreationService.test.ts
+++ b/api/tests/services/notificationCreationService.test.ts
@@ -44,7 +44,9 @@ describe("Notification Creation Service", () => {
 
     describe("Reply Notification", () => {
         test("Should save notification for comment reply", async () => {
-            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+            notificationCreator = new TestCommentNotification(
+                notificationRepositoryMock
+            );
 
             notificationRepositoryMock.save.mockReturnValueOnce({
                 Id: 1,
@@ -56,11 +58,11 @@ describe("Notification Creation Service", () => {
             });
 
             const result = await notificationCreator.saveNotification(2);
-            const response = makeNotificationMock({userId: 2});
+            const response = makeNotificationMock({ userId: 2 });
 
             expect(notificationRepositoryMock.save).toHaveBeenCalledWith({
                 User: {
-                    Id: 2
+                    Id: 2,
                 },
                 Text: "Test",
                 Type: NotificationType.COMMENT_REPLY,
@@ -69,22 +71,34 @@ describe("Notification Creation Service", () => {
         });
 
         test("Should throw error with invalid user id 0", async () => {
-            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+            notificationCreator = new TestCommentNotification(
+                notificationRepositoryMock
+            );
 
             const userId = 0;
-            await expect(notificationCreator.saveNotification(userId)).rejects.toThrow(UserIdError);
+            await expect(
+                notificationCreator.saveNotification(userId)
+            ).rejects.toThrow(UserIdError);
         });
 
         test("Should throw error with invalid user id -1", async () => {
-            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+            notificationCreator = new TestCommentNotification(
+                notificationRepositoryMock
+            );
 
             const userId = -1;
-            await expect(notificationCreator.saveNotification(userId)).rejects.toThrow(UserIdError);
+            await expect(
+                notificationCreator.saveNotification(userId)
+            ).rejects.toThrow(UserIdError);
         });
 
         test("Should throw error with invalid user id -1", async () => {
-            notificationCreator = new EmptyTestNotification(notificationRepositoryMock);
-            await expect(notificationCreator.saveNotification(10)).rejects.toThrow(EmptyNotificationError);
+            notificationCreator = new EmptyTestNotification(
+                notificationRepositoryMock
+            );
+            await expect(
+                notificationCreator.saveNotification(10)
+            ).rejects.toThrow(EmptyNotificationError);
         });
     });
 });

--- a/api/tests/services/notificationCreationService.test.ts
+++ b/api/tests/services/notificationCreationService.test.ts
@@ -1,0 +1,90 @@
+import { NotificationType } from "../../src/entity/notification.entity";
+import { EmptyNotificationError } from "../../src/errors/EmptyNotificationError";
+import { UserIdError } from "../../src/errors/UserIdError";
+import NotificationCreationService from "../../src/services/notificationCreationService";
+
+class TestCommentNotification extends NotificationCreationService {
+    getNotificationText(): string {
+        return "Test";
+    }
+
+    getNotificationType(): NotificationType {
+        return NotificationType.COMMENT_REPLY;
+    }
+}
+
+class EmptyTestNotification extends NotificationCreationService {
+    getNotificationText(): string {
+        return "";
+    }
+
+    getNotificationType(): NotificationType {
+        return NotificationType.COMMENT_REPLY;
+    }
+}
+
+const makeNotificationMock = (notificationObj = {} as any) => {
+    return {
+        id: notificationObj.id || 1,
+        userId: notificationObj.userId || 1,
+        text: notificationObj.text || "Test",
+        read: notificationObj.read || false,
+    };
+};
+
+describe("Notification Creation Service", () => {
+    let notificationCreator: TestCommentNotification;
+    let notificationRepositoryMock: any;
+
+    beforeEach(() => {
+        notificationRepositoryMock = {
+            save: jest.fn(),
+        };
+    });
+
+    describe("Reply Notification", () => {
+        test("Should save notification for comment reply", async () => {
+            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+
+            notificationRepositoryMock.save.mockReturnValueOnce({
+                Id: 1,
+                User: {
+                    Id: 2,
+                },
+                Text: "Test",
+                Type: NotificationType.COMMENT_REPLY,
+            });
+
+            const result = await notificationCreator.saveNotification(2);
+            const response = makeNotificationMock({userId: 2});
+
+            expect(notificationRepositoryMock.save).toHaveBeenCalledWith({
+                User: {
+                    Id: 2
+                },
+                Text: "Test",
+                Type: NotificationType.COMMENT_REPLY,
+            });
+            expect(result).toEqual(response);
+        });
+
+        test("Should throw error with invalid user id 0", async () => {
+            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+
+            const userId = 0;
+            await expect(notificationCreator.saveNotification(userId)).rejects.toThrow(UserIdError);
+        });
+
+        test("Should throw error with invalid user id -1", async () => {
+            notificationCreator = new TestCommentNotification(notificationRepositoryMock);
+
+            const userId = -1;
+            await expect(notificationCreator.saveNotification(userId)).rejects.toThrow(UserIdError);
+        });
+
+        test("Should throw error with invalid user id -1", async () => {
+            notificationCreator = new EmptyTestNotification(notificationRepositoryMock);
+            await expect(notificationCreator.saveNotification(10)).rejects.toThrow(EmptyNotificationError);
+        });
+    });
+});

--- a/api/tests/services/notificationCreationService.test.ts
+++ b/api/tests/services/notificationCreationService.test.ts
@@ -44,25 +44,28 @@ describe("Notification Creation Service", () => {
 
     describe("Reply Notification", () => {
         test("Should save notification for comment reply", async () => {
+            const userId: number = 2;
+
             notificationCreator = new TestCommentNotification(
-                notificationRepositoryMock
+                notificationRepositoryMock,
+                userId
             );
 
             notificationRepositoryMock.save.mockReturnValueOnce({
                 Id: 1,
                 User: {
-                    Id: 2,
+                    Id: userId,
                 },
                 Text: "Test",
                 Type: NotificationType.COMMENT_REPLY,
             });
 
-            const result = await notificationCreator.saveNotification(2);
-            const response = makeNotificationMock({ userId: 2 });
+            const result = await notificationCreator.saveNotification();
+            const response = makeNotificationMock({ userId: userId });
 
             expect(notificationRepositoryMock.save).toHaveBeenCalledWith({
                 User: {
-                    Id: 2,
+                    Id: userId,
                 },
                 Text: "Test",
                 Type: NotificationType.COMMENT_REPLY,
@@ -71,33 +74,38 @@ describe("Notification Creation Service", () => {
         });
 
         test("Should throw error with invalid user id 0", async () => {
+            const userId: number = 0;
             notificationCreator = new TestCommentNotification(
-                notificationRepositoryMock
+                notificationRepositoryMock,
+                userId
             );
 
-            const userId = 0;
             await expect(
-                notificationCreator.saveNotification(userId)
+                notificationCreator.saveNotification()
             ).rejects.toThrow(UserIdError);
         });
 
         test("Should throw error with invalid user id -1", async () => {
+            const userId: number = -1;
             notificationCreator = new TestCommentNotification(
-                notificationRepositoryMock
+                notificationRepositoryMock,
+                userId
             );
 
-            const userId = -1;
             await expect(
-                notificationCreator.saveNotification(userId)
+                notificationCreator.saveNotification()
             ).rejects.toThrow(UserIdError);
         });
 
-        test("Should throw error with invalid user id -1", async () => {
+        test("Should throw error with empty notification error", async () => {
+            const userId: number = 10;
             notificationCreator = new EmptyTestNotification(
-                notificationRepositoryMock
+                notificationRepositoryMock,
+                userId
             );
+
             await expect(
-                notificationCreator.saveNotification(10)
+                notificationCreator.saveNotification()
             ).rejects.toThrow(EmptyNotificationError);
         });
     });


### PR DESCRIPTION
## Description
This PR makes creating notifications possible for any service in the API. The creation of notifications is done by using a *template method*. There is an abstract class called **NotificationCreationService** that is responsible for creating a notification record on the database and any class that inherits from it has to implement both the ```getNotificationText()``` and ```getNotificationType()``` methods. The ```saveNotification()``` is already implemented in the abstract class.

## Main issue

- #36 

## Related issues

- #39 

## Pull request type

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] Other (please describe):

## Tests

-   [x] All unit tests passed
-   [x] Added new unit tests

## Documentation

-   [ ] Add documentation
-   [ ] Update documentation
